### PR TITLE
Bug Fixes for electrons, photons and superclusters

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronGSCrysFixer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronGSCrysFixer.cc
@@ -156,12 +156,14 @@ void GsfElectronGSCrysFixer::produce( edm::Event & iEvent, const edm::EventSetup
 
       reco::GsfElectron::ShowerShape full5x5ShowerShape = GainSwitchTools::redoEcalShowerShape<true>(newEle.full5x5_showerShape(),newEle.superCluster(),&ebRecHits,topology_,geometry_);
       reco::GsfElectron::ShowerShape showerShape = GainSwitchTools::redoEcalShowerShape<false>(newEle.showerShape(),newEle.superCluster(),&ebRecHits,topology_,geometry_);
-      newEle.full5x5_setShowerShape(full5x5ShowerShape);   
-      newEle.setShowerShape(showerShape);   
-
+    
       float eNewSCOverEOldSC = newEle.superCluster()->energy()/oldEle.superCluster()->energy();
       GainSwitchTools::correctHadem(showerShape,eNewSCOverEOldSC,GainSwitchTools::ShowerShapeType::Fractions);
       GainSwitchTools::correctHadem(full5x5ShowerShape,eNewSCOverEOldSC,GainSwitchTools::ShowerShapeType::Full5x5);
+
+      newEle.full5x5_setShowerShape(full5x5ShowerShape);   
+      newEle.setShowerShape(showerShape);   
+
 
       if( gedRegression_ )
 	gedRegression_->modifyObject(newEle);

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonGSCrysFixer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonGSCrysFixer.cc
@@ -191,10 +191,10 @@ GEDPhotonGSCrysFixer::produce(edm::Event& _event, const edm::EventSetup& _setup)
       outPhoton.setShowerShapeVariables(newSS);
 
       reco::Photon::ShowerShape new55SS;
-      newSS.e1x5 = noZS::EcalClusterTools::e1x5(newSeed, &ebHits, topology_);
-      newSS.e2x5 = noZS::EcalClusterTools::e2x5Max(newSeed, &ebHits, topology_);
-      newSS.e3x3 = noZS::EcalClusterTools::e3x3(newSeed, &ebHits, topology_);
-      newSS.e5x5 = noZS::EcalClusterTools::e5x5(newSeed, &ebHits, topology_);
+      new55SS.e1x5 = noZS::EcalClusterTools::e1x5(newSeed, &ebHits, topology_);
+      new55SS.e2x5 = noZS::EcalClusterTools::e2x5Max(newSeed, &ebHits, topology_);
+      new55SS.e3x3 = noZS::EcalClusterTools::e3x3(newSeed, &ebHits, topology_);
+      new55SS.e5x5 = noZS::EcalClusterTools::e5x5(newSeed, &ebHits, topology_);
       new55SS.maxEnergyXtal = noZS::EcalClusterTools::eMax(newSeed, &ebHits);
       new55SS.sigmaEtaEta = std::sqrt(cov55[0]);
       new55SS.sigmaIetaIeta = std::sqrt(locCov55[0]);


### PR DESCRIPTION
Here is a bug fix for the photon and electron showershapes that was introduced in the last updates.

Also I fixed a case where a subcluster can belong to two superclusters.  Its rare but it does happen. Its when during the particle flow clustering step, the pf supercluster gets an extra cluster with that cluster being assigned to another supercluster in the refined stage. As the orginal pf supercluster didnt have that cluster, it didnt get removed form the supercluster properly. 